### PR TITLE
Suppress inclusion of duplicate rpaths.

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include <cstdlib>
 #include <map>
 #include <utility>
-
+#include <algorithm>
 #include <sys/param.h>
 
 #include "Utils.h"
@@ -197,7 +197,11 @@ bool rpathFound(const string& rpath) { return rpath_to_fullpath.find(rpath) != r
 
 map<string, vector<string>> rpaths_per_file;
 vector<string> getRpathsForFile(const string& file) { return rpaths_per_file[file]; }
-void addRpathForFile(const string& file, const string& rpath) { rpaths_per_file[file].push_back(rpath); }
+void addRpathForFile(const string& file, const string& rpath) 
+{
+    if (std::find(rpaths_per_file[file].begin(), rpaths_per_file[file].end(), rpath) == rpaths_per_file[file].end()) return; 
+    rpaths_per_file[file].push_back(rpath); 
+}
 bool fileHasRpath(const string& file) { return rpaths_per_file.find(file) != rpaths_per_file.end(); }
 
 } // namespace Settings

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -199,7 +199,7 @@ map<string, vector<string>> rpaths_per_file;
 vector<string> getRpathsForFile(const string& file) { return rpaths_per_file[file]; }
 void addRpathForFile(const string& file, const string& rpath) 
 {
-    if (std::find(rpaths_per_file[file].begin(), rpaths_per_file[file].end(), rpath) == rpaths_per_file[file].end()) return; 
+    if (std::find(rpaths_per_file[file].begin(), rpaths_per_file[file].end(), rpath) != rpaths_per_file[file].end()) return; 
     rpaths_per_file[file].push_back(rpath); 
 }
 bool fileHasRpath(const string& file) { return rpaths_per_file.find(file) != rpaths_per_file.end(); }


### PR DESCRIPTION
On macOS Monterey with an M1 Mac Mini, I noticed that it was trying to run install_name_tool twice for the same dynamic library while packaging drowe67/freedv-gui. This PR prevents that from happening and allows macdylibbundler to successfully complete.